### PR TITLE
fix: otp-28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ req_embed-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+.elixir_ls/

--- a/lib/req_embed/providers.ex
+++ b/lib/req_embed/providers.ex
@@ -36,12 +36,9 @@ defmodule ReqEmbed.Providers do
                      url: String.replace(endpoint["url"], "{format}", "json") |> URI.new!(),
                      schemes:
                        Enum.map(endpoint["schemes"] || [], fn pattern ->
-                         pattern =
-                           pattern
-                           |> String.replace(".", "\\.")
-                           |> String.replace("*", ".*")
-
-                         Regex.compile!(pattern)
+                         pattern
+                         |> String.replace(".", "\\.")
+                         |> String.replace("*", ".*")
                        end)
                    }
                  end)
@@ -69,7 +66,7 @@ defmodule ReqEmbed.Providers do
     Enum.find(providers, fn provider ->
       Enum.any?(provider.endpoints, fn endpoint ->
         Enum.any?(endpoint.schemes, fn pattern ->
-          Regex.match?(pattern, url)
+          Regex.match?(~r/#{pattern}/, url)
         end)
       end)
     end)

--- a/test/req_embed_test.exs
+++ b/test/req_embed_test.exs
@@ -22,7 +22,7 @@ defmodule ReqEmbedTest do
                        query: nil,
                        fragment: nil
                      },
-                     schemes: [~r/http:\/\/www\.23hq\.com\/.*\/photo\/.*/]
+                     schemes: ["http://www\\.23hq\\.com/.*/photo/.*"]
                    }
                  ]
                }


### PR DESCRIPTION
Remove regex ref from module attribute.

Fix #11

Still need to find a way to optimize providers lookup.

```
~/code/github/leandrocp/req_embed lp-fix-otp-28* 6s
❯ elixir --version
Erlang/OTP 28 [erts-16.0] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]

Elixir 1.19.0-dev (41d1a72) (compiled with Erlang/OTP 28)

~/code/github/leandrocp/req_embed lp-fix-otp-28*
❯ mix compile

~/code/github/leandrocp/req_embed lp-fix-otp-28*
❯ echo $?
0

~/code/github/leandrocp/req_embed lp-fix-otp-28*
❯ mix test
Running ExUnit with seed: 20226, max_cases: 20

.............
16:41:43.950 [debug] redirecting to https://publish.twitter.com/oembed?format=json&url=https%3A%2F%2Fx.com%2FThinkingElixir%2Fstatus%2F1848702455313318251
....
Finished in 6.2 seconds (0.00s async, 6.2s sync)
17 tests, 0 failures
```