### PR TITLE
ci: include provider names in update titles

### DIFF
--- a/.github/workflows/update-providers.yml
+++ b/.github/workflows/update-providers.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Run vendor-providers
         run: just vendor-providers
 
+      - name: Detect changed providers
+        id: provider-changes
+        shell: bash
+        run: |
+          names=$(
+            jq --slurp --raw-output '
+              (.[0] | INDEX(.provider_name)) as $before
+              | (.[1] | INDEX(.provider_name)) as $after
+              | ((($before | keys_unsorted) + ($after | keys_unsorted)) | unique)
+              | map(select($before[.] != $after[.]))
+              | join(", ")
+            ' <(git show HEAD:priv/providers.json) priv/providers.json
+          )
+
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         if: ${{ env.CI_TOKEN != '' }}
         uses: peter-evans/create-pull-request@v8
@@ -35,8 +51,8 @@ jobs:
           token: ${{ env.CI_TOKEN }}
           add-paths: |
             priv
-          commit-message: "feat: update oembed providers"
-          title: "feat: update oembed providers"
+          commit-message: "feat: update providers: ${{ steps.provider-changes.outputs.names }}"
+          title: "feat: update providers: ${{ steps.provider-changes.outputs.names }}"
           body: |
             Automated PR to update oembed providers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Include changed provider names in automated update pull requests and commits
+
 ## [0.3.8](https://github.com/leandrocp/req_embed/compare/v0.3.7...v0.3.8) (2026-07-16)
 
 


### PR DESCRIPTION
## Summary

- detect added, removed, and modified providers after refreshing `priv/providers.json`
- use the provider list in both the automated commit message and PR title
- document the CI behavior change under `Unreleased`

## Why

Release Please uses the merged provider-update PR titles in generated release notes. The workflow currently gives every update the same generic title, so releases cannot show which providers changed.

Future entries will read like `update providers: ChanceIndex, Clipform, Coloring Monster` while retaining the `feat:` prefix needed for Release Please classification.

## Validation

- `actionlint`
- `git diff --check HEAD^ HEAD`
- replayed the detector against provider updates `2984828`, `02a3e06`, and `1aceee8`, confirming the expected provider names for each